### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Supported APIs:
 - Usage
 
 
-Examples - [Full Documentation](https://www.paralleldots.com/docs/)
+Examples - [Full Documentation](https://www.paralleldots.com/docs)
 -------------------------------
 
 ```javascript
@@ -154,28 +154,12 @@ pd.taxonomy('Deutsche Bank CEO sees far fewer than 4,000 Brexit-related moves: p
 		console.log(error);
 	})
 
-pd.taxonomy('Deutsche Bank CEO sees far fewer than 4,000 Brexit-related moves: paper')
-	.then((response) => {
-		console.log(response);
-	})
-	.catch((error) => {
-		console.log(error);
-	})
-
 pd.multilingualSentiment('Barcelona es una ciudad hermosa','es')
 	.then((response) => {
 		console.log(response);
 	})
 	.catch((err) =>{
 		console.log(err);
-	})
-
-pd.sentimentSocial('I left my camera at home')
-	.then((response) => {
-		console.log(response);
-	})
-	.catch((error) => {
-		console.log(error);
 	})
 
 const category = {


### PR DESCRIPTION
### Description
In this pull request I'm just fixing a little issue on the `README`, the link to docs results into a 404 and we have a few problems with the examples:

The first problem is a duplicated block for a taxonomy request, and also a call for a not exported method. (at least on the last published `npm` version of this package)

About the  not exported method, here is a paralleldots `console.log` output:
```
parallel: { 
     apiKey: 'HIDDEN_FOR_SAFETY,
     usage: [Function: usage],
     sentiment: [Function: sentiment],
     abuse: [Function: abuse],
     semantic: [Function: semantic],
     ner: [Function: ner],
     emotion: [Function: emotion],
     intent: [Function: intent],
     keywords: [Function: keywords],
     multilangKeywords: [Function: multilangKeywords],
     taxonomy: [Function: taxonomy],
     multilingualSentiment: [Function: multilingualSentiment],
     customClassifier: [Function: customClassifier],
     textParser: [Function: textParser],
     phraseExtractor: [Function: phraseExtractor],
     popularity: [Function: popularity],
     nsfw: [Function: nsfw],
     facialEmotion: [Function: facialEmotion],
     objectRecognizer: [Function: objectRecognizer]
}
```